### PR TITLE
round() = inaccurate position.

### DIFF
--- a/BuilderTools/src/czechpmdevs/buildertools/commands/FirstPositionCommand.php
+++ b/BuilderTools/src/czechpmdevs/buildertools/commands/FirstPositionCommand.php
@@ -51,7 +51,18 @@ class FirstPositionCommand extends BuilderToolsCommand {
             $sender->sendMessage("§cThis command can be used only in game!");
             return;
         }
-        Selectors::addSelector($sender, 1, $position = new Position((int)round($sender->getX()), (int)round($sender->getY()), (int)round($sender->getZ()), $sender->getLevel()));
+        if (isset($args[0])) {
+            if (isset($args[1])) {
+                if (isset($args[2])) {
+                    Selectors::addSelector($sender, 1, $position = new Position((int)intval($args[0]), (int)intval($args[1]), (int)intval($args[2]), $sender->getLevel()));
+                    $sender->sendMessage(BuilderTools::getPrefix()."§aSelected first position at {$position->getX()}, {$position->getY()}, {$position->getZ()}");
+                                return;
+                }
+            }
+            $sender->sendMessage("§cInvalid coordinates given!");
+            return;
+        }
+        Selectors::addSelector($sender, 1, $position = new Position((int)intval($sender->getX()), (int)intval($sender->getY()), (int)intval($sender->getZ()), $sender->getLevel()));
         $sender->sendMessage(BuilderTools::getPrefix()."§aSelected first position at {$position->getX()}, {$position->getY()}, {$position->getZ()}");
     }
 }

--- a/BuilderTools/src/czechpmdevs/buildertools/commands/FirstPositionCommand.php
+++ b/BuilderTools/src/czechpmdevs/buildertools/commands/FirstPositionCommand.php
@@ -51,7 +51,7 @@ class FirstPositionCommand extends BuilderToolsCommand {
             $sender->sendMessage("§cThis command can be used only in game!");
             return;
         }
-        Selectors::addSelector($sender, 1, $position = new Position((int)round($sender->getX()), (int)round($sender->getY()), (int)round($sender->getZ()), $sender->getLevel()));
+        Selectors::addSelector($sender, 1, $position = new Position((int)intval($sender->getX()), (int)intval($sender->getY()), (int)intval($sender->getZ()), $sender->getLevel()));
         $sender->sendMessage(BuilderTools::getPrefix()."§aSelected first position at {$position->getX()}, {$position->getY()}, {$position->getZ()}");
     }
 }

--- a/BuilderTools/src/czechpmdevs/buildertools/commands/FirstPositionCommand.php
+++ b/BuilderTools/src/czechpmdevs/buildertools/commands/FirstPositionCommand.php
@@ -51,7 +51,7 @@ class FirstPositionCommand extends BuilderToolsCommand {
             $sender->sendMessage("§cThis command can be used only in game!");
             return;
         }
-        Selectors::addSelector($sender, 1, $position = new Position((int)intval($sender->getX()), (int)intval($sender->getY()), (int)intval($sender->getZ()), $sender->getLevel()));
+        Selectors::addSelector($sender, 1, $position = new Position((int)round($sender->getX()), (int)round($sender->getY()), (int)round($sender->getZ()), $sender->getLevel()));
         $sender->sendMessage(BuilderTools::getPrefix()."§aSelected first position at {$position->getX()}, {$position->getY()}, {$position->getZ()}");
     }
 }

--- a/BuilderTools/src/czechpmdevs/buildertools/commands/SecondPositionCommand.php
+++ b/BuilderTools/src/czechpmdevs/buildertools/commands/SecondPositionCommand.php
@@ -47,7 +47,18 @@ class SecondPositionCommand extends BuilderToolsCommand {
             $sender->sendMessage("§cThis command can be used only in game!");
             return;
         }
-        Selectors::addSelector($sender, 2, $position = new Position((int)round($sender->getX()), (int)round($sender->getY()), (int)round($sender->getZ()), $sender->getLevel()));
+        if (isset($args[0])) {
+            if (isset($args[1])) {
+                if (isset($args[2])) {
+                    Selectors::addSelector($sender, 2, $position = new Position((int)intval($args[0]), (int)intval($args[1]), (int)intval($args[2]), $sender->getLevel()));
+                    $sender->sendMessage(BuilderTools::getPrefix()."§aSelected first position at {$position->getX()}, {$position->getY()}, {$position->getZ()}");
+                                return;
+                }
+            }
+            $sender->sendMessage("§cInvalid coordinates given!");
+            return;
+        }
+        Selectors::addSelector($sender, 2, $position = new Position((int)intval($sender->getX()), (int)intval($sender->getY()), (int)intval($sender->getZ()), $sender->getLevel()));
         $sender->sendMessage(BuilderTools::getPrefix()."§aSelected second position at {$position->getX()}, {$position->getY()}, {$position->getZ()}");
     }
 }

--- a/BuilderTools/src/czechpmdevs/buildertools/commands/SecondPositionCommand.php
+++ b/BuilderTools/src/czechpmdevs/buildertools/commands/SecondPositionCommand.php
@@ -47,7 +47,7 @@ class SecondPositionCommand extends BuilderToolsCommand {
             $sender->sendMessage("§cThis command can be used only in game!");
             return;
         }
-        Selectors::addSelector($sender, 2, $position = new Position((int)intval($sender->getX()), (int)intval($sender->getY()), (int)intval($sender->getZ()), $sender->getLevel()));
+        Selectors::addSelector($sender, 2, $position = new Position((int)round($sender->getX()), (int)round($sender->getY()), (int)round($sender->getZ()), $sender->getLevel()));
         $sender->sendMessage(BuilderTools::getPrefix()."§aSelected second position at {$position->getX()}, {$position->getY()}, {$position->getZ()}");
     }
 }

--- a/BuilderTools/src/czechpmdevs/buildertools/commands/SecondPositionCommand.php
+++ b/BuilderTools/src/czechpmdevs/buildertools/commands/SecondPositionCommand.php
@@ -47,7 +47,7 @@ class SecondPositionCommand extends BuilderToolsCommand {
             $sender->sendMessage("§cThis command can be used only in game!");
             return;
         }
-        Selectors::addSelector($sender, 2, $position = new Position((int)round($sender->getX()), (int)round($sender->getY()), (int)round($sender->getZ()), $sender->getLevel()));
+        Selectors::addSelector($sender, 2, $position = new Position((int)intval($sender->getX()), (int)intval($sender->getY()), (int)intval($sender->getZ()), $sender->getLevel()));
         $sender->sendMessage(BuilderTools::getPrefix()."§aSelected second position at {$position->getX()}, {$position->getY()}, {$position->getZ()}");
     }
 }


### PR DESCRIPTION
Because of `round()`, it gives an inaccurate position when standing at the edge of blocks. This impacts `//copy`, selectors, and some other commands.

To resolve this, simply truncate the float instead of rounding it. I used `intval()` here (2 years again). On second thought, type-casting `(int)` could give a better performance and readability.