### PR TITLE
Fixed to decode numeric IDs correctly

### DIFF
--- a/src/czechpmdevs/buildertools/utils/StringToBlockDecoder.php
+++ b/src/czechpmdevs/buildertools/utils/StringToBlockDecoder.php
@@ -116,10 +116,6 @@ final class StringToBlockDecoder implements BlockIdentifierList {
 				continue;
 			}
 
-			if($item === null) {
-				continue;
-			}
-
 			$class = $item->getBlock();
 			if($class->getId() === 0 && $item->getId() !== 0) {
 				continue;

--- a/src/czechpmdevs/buildertools/utils/StringToBlockDecoder.php
+++ b/src/czechpmdevs/buildertools/utils/StringToBlockDecoder.php
@@ -23,6 +23,8 @@ namespace czechpmdevs\buildertools\utils;
 use czechpmdevs\buildertools\blockstorage\identifiers\BlockIdentifierList;
 use OutOfBoundsException;
 use pocketmine\item\Item;
+use pocketmine\item\LegacyStringToItemParser;
+use pocketmine\item\LegacyStringToItemParserException;
 use pocketmine\item\StringToItemParser;
 use function array_rand;
 use function count;
@@ -108,7 +110,12 @@ final class StringToBlockDecoder implements BlockIdentifierList {
 				$block = substr($entry, $pos + 1);
 			}
 
-			$item = StringToItemParser::getInstance()->parse($block);
+			try {
+				$item = StringToItemParser::getInstance()->parse($block) ?? LegacyStringToItemParser::getInstance()->parse($block);
+			} catch (LegacyStringToItemParserException) {
+				continue;
+			}
+
 			if($item === null) {
 				continue;
 			}


### PR DESCRIPTION
Since 2842f6e17bc75d53526158ea6660d01cc58c9ee3, numerical IDs (e.g. `1`, `1:2`) are no longer decoded correctly.
Fix the issue that commands like `/fill 1` cannot be used.