### PR TITLE
Update for PM5 Alpha7 and more

### DIFF
--- a/src/czechpmdevs/buildertools/async/BuilderToolsAsyncTask.php
+++ b/src/czechpmdevs/buildertools/async/BuilderToolsAsyncTask.php
@@ -20,8 +20,6 @@ declare(strict_types=1);
 
 namespace czechpmdevs\buildertools\async;
 
-use GlobalLogger;
-use Logger;
 use pocketmine\scheduler\AsyncTask;
 use Throwable;
 
@@ -49,10 +47,6 @@ abstract class BuilderToolsAsyncTask extends AsyncTask {
 	final public function onCompletion(): void {
 		$this->complete();
 		AsyncQueue::callCallback($this);
-	}
-
-	protected function getLogger(): Logger {
-		return GlobalLogger::get();
 	}
 
 	public function getErrorMessage(): ?string {

--- a/src/czechpmdevs/buildertools/async/BuilderToolsAsyncTask.php
+++ b/src/czechpmdevs/buildertools/async/BuilderToolsAsyncTask.php
@@ -20,19 +20,13 @@ declare(strict_types=1);
 
 namespace czechpmdevs\buildertools\async;
 
-use AttachableLogger;
-use czechpmdevs\buildertools\BuilderTools;
+use GlobalLogger;
+use Logger;
 use pocketmine\scheduler\AsyncTask;
 use Throwable;
 
 abstract class BuilderToolsAsyncTask extends AsyncTask {
-	private AttachableLogger $logger;
-
 	private string $error = "";
-
-	public function __construct() {
-		$this->logger = BuilderTools::getInstance()->getLogger();
-	}
 
 	abstract public function execute(): void;
 
@@ -57,8 +51,8 @@ abstract class BuilderToolsAsyncTask extends AsyncTask {
 		AsyncQueue::callCallback($this);
 	}
 
-	protected function getLogger(): AttachableLogger {
-		return $this->logger;
+	protected function getLogger(): Logger {
+		return GlobalLogger::get();
 	}
 
 	public function getErrorMessage(): ?string {

--- a/src/czechpmdevs/buildertools/async/schematics/SchematicCreateTask.php
+++ b/src/czechpmdevs/buildertools/async/schematics/SchematicCreateTask.php
@@ -43,8 +43,6 @@ class SchematicCreateTask extends BuilderToolsAsyncTask {
 	 * @param class-string<Schematic> $format
 	 */
 	public function __construct(string $targetFilePath, string $format, BlockArray $blockArray) {
-		parent::__construct();
-
 		$this->targetFilePath = $targetFilePath;
 		$this->format = $format;
 		$this->blockArray = serialize($blockArray);

--- a/src/czechpmdevs/buildertools/async/schematics/SchematicLoadTask.php
+++ b/src/czechpmdevs/buildertools/async/schematics/SchematicLoadTask.php
@@ -34,7 +34,7 @@ class SchematicLoadTask extends BuilderToolsAsyncTask {
 	public string $file;
 	public string $name;
 
-	public CompressedBlockArray $blockStorage;
+	public string $blockStorage;
 
 	public function __construct(string $file) {
 		$this->file = $file;
@@ -62,6 +62,6 @@ class SchematicLoadTask extends BuilderToolsAsyncTask {
 		$blockArray = $schematic->load($rawData);
 
 		$this->name = basename($this->file, "." . $schematic::getFileExtension());
-		$this->blockStorage = new CompressedBlockArray($blockArray);
+		$this->blockStorage = igbinary_serialize(new CompressedBlockArray($blockArray));
 	}
 }

--- a/src/czechpmdevs/buildertools/async/schematics/SchematicLoadTask.php
+++ b/src/czechpmdevs/buildertools/async/schematics/SchematicLoadTask.php
@@ -24,6 +24,7 @@ use czechpmdevs\buildertools\async\BuilderToolsAsyncTask;
 use czechpmdevs\buildertools\blockstorage\CompressedBlockArray;
 use czechpmdevs\buildertools\schematics\format\Schematic;
 use czechpmdevs\buildertools\schematics\SchematicsManager;
+use pocketmine\thread\NonThreadSafeValue;
 use RuntimeException;
 use function basename;
 use function file_exists;
@@ -34,7 +35,7 @@ class SchematicLoadTask extends BuilderToolsAsyncTask {
 	public string $file;
 	public string $name;
 
-	public string $blockStorage;
+	public NonThreadSafeValue $blockStorage;
 
 	public function __construct(string $file) {
 		$this->file = $file;
@@ -62,6 +63,6 @@ class SchematicLoadTask extends BuilderToolsAsyncTask {
 		$blockArray = $schematic->load($rawData);
 
 		$this->name = basename($this->file, "." . $schematic::getFileExtension());
-		$this->blockStorage = igbinary_serialize(new CompressedBlockArray($blockArray));
+		$this->blockStorage = new NonThreadSafeValue(new CompressedBlockArray($blockArray));
 	}
 }

--- a/src/czechpmdevs/buildertools/async/schematics/SchematicLoadTask.php
+++ b/src/czechpmdevs/buildertools/async/schematics/SchematicLoadTask.php
@@ -37,8 +37,6 @@ class SchematicLoadTask extends BuilderToolsAsyncTask {
 	public CompressedBlockArray $blockStorage;
 
 	public function __construct(string $file) {
-		parent::__construct();
-
 		$this->file = $file;
 	}
 

--- a/src/czechpmdevs/buildertools/editors/object/FillSession.php
+++ b/src/czechpmdevs/buildertools/editors/object/FillSession.php
@@ -121,7 +121,7 @@ class FillSession {
 
 		for($y = World::Y_MIN; $y < World::Y_MAX; $y++) {
 			/** @phpstan-ignore-next-line */
-			$this->explorer->currentChunk->setBiomeId($x & 0xf, $y & 0xf, $z & 0xf, $id); //TODO: Properly support subchunks with y axis
+			$this->explorer->currentChunk->setBiomeId($x & 0xf, $y & 0xf, $z & 0xf, $id);
 		}
 
 		++$this->blocksChanged;

--- a/src/czechpmdevs/buildertools/editors/object/FillSession.php
+++ b/src/czechpmdevs/buildertools/editors/object/FillSession.php
@@ -84,7 +84,7 @@ class FillSession {
 		$this->saveChanges($x, $y, $z);
 
 		/** @phpstan-ignore-next-line */
-		$this->explorer->currentSubChunk->setFullBlock($x & 0xf, $y & 0xf, $z & 0xf, $fullStateId);
+		$this->explorer->currentSubChunk->setBlockStateId($x & 0xf, $y & 0xf, $z & 0xf, $fullStateId);
 		++$this->blocksChanged;
 	}
 
@@ -97,7 +97,7 @@ class FillSession {
 		}
 
 		/** @phpstan-ignore-next-line */
-		$fullStateId = $this->explorer->currentSubChunk->getFullBlock($x & 0xf, $y & 0xf, $z & 0xf);
+		$fullStateId = $this->explorer->currentSubChunk->getBlockStateId($x & 0xf, $y & 0xf, $z & 0xf);
 	}
 
 	/**
@@ -109,7 +109,7 @@ class FillSession {
 		}
 
 		/** @phpstan-ignore-next-line */
-		$this->lastHash = $this->explorer->currentSubChunk->getFullBlock($x & 0xf, $y & 0xf, $z & 0xf);
+		$this->lastHash = $this->explorer->currentSubChunk->getBlockStateId($x & 0xf, $y & 0xf, $z & 0xf);
 
 		$id = $this->lastHash >> 4;
 	}
@@ -129,7 +129,7 @@ class FillSession {
 			$this->explorer->moveTo($x, $y, $z);
 
 			/** @phpstan-ignore-next-line */
-			$id = $this->explorer->currentChunk->getFullBlock($x & 0xf, $y & 0xf, $z & 0xf) >> Block::INTERNAL_STATE_DATA_BITS;
+			$id = $this->explorer->currentChunk->getBlockStateId($x & 0xf, $y & 0xf, $z & 0xf) >> Block::INTERNAL_STATE_DATA_BITS;
 			if($id !== 0) {
 				return true;
 			}
@@ -219,7 +219,7 @@ class FillSession {
 	protected function saveChanges(int $x, int $y, int $z): void {
 		if($this->saveChanges) {
 			/** @phpstan-ignore-next-line */
-			$this->changes->addBlockAt($x, $y, $z, $this->explorer->currentSubChunk->getFullBlock($x & 0xf, $y & 0xf, $z & 0xf));
+			$this->changes->addBlockAt($x, $y, $z, $this->explorer->currentSubChunk->getBlockStateId($x & 0xf, $y & 0xf, $z & 0xf));
 		}
 	}
 

--- a/src/czechpmdevs/buildertools/editors/object/FillSession.php
+++ b/src/czechpmdevs/buildertools/editors/object/FillSession.php
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *	 http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -119,10 +119,10 @@ class FillSession {
 			return;
 		}
 
-        for($y = World::Y_MIN; $y < World::Y_MAX; $y++) {
-            /** @phpstan-ignore-next-line */
-            $this->explorer->currentChunk->setBiomeId($x & 0xf, $y & 0xf, $z & 0xf, $id); //TODO: Properly support subchunks with y axis
-        }
+		for($y = World::Y_MIN; $y < World::Y_MAX; $y++) {
+			/** @phpstan-ignore-next-line */
+			$this->explorer->currentChunk->setBiomeId($x & 0xf, $y & 0xf, $z & 0xf, $id); //TODO: Properly support subchunks with y axis
+		}
 
 		++$this->blocksChanged;
 	}

--- a/src/czechpmdevs/buildertools/editors/object/FillSession.php
+++ b/src/czechpmdevs/buildertools/editors/object/FillSession.php
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *	 http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/czechpmdevs/buildertools/editors/object/FillSession.php
+++ b/src/czechpmdevs/buildertools/editors/object/FillSession.php
@@ -119,8 +119,11 @@ class FillSession {
 			return;
 		}
 
-		/** @phpstan-ignore-next-line */
-		$this->explorer->currentChunk->setBiomeId($x & 0xf, $z & 0xf, $id);
+        for($y = World::Y_MIN; $y < World::Y_MAX; $y++) {
+            /** @phpstan-ignore-next-line */
+            $this->explorer->currentChunk->setBiomeId($x & 0xf, $y & 0xf, $z & 0xf, $id); //TODO: Properly support subchunks with y axis
+        }
+
 		++$this->blocksChanged;
 	}
 

--- a/src/czechpmdevs/buildertools/editors/object/MaskedFillSession.php
+++ b/src/czechpmdevs/buildertools/editors/object/MaskedFillSession.php
@@ -44,7 +44,7 @@ class MaskedFillSession extends FillSession {
 		if($this->mask !== null && (
 			!$this->mask->containsBlock(
 				/** @phpstan-ignore-next-line */
-				$this->explorer->currentSubChunk->getFullBlock($x & 0xf, $y & 0xf, $z & 0xf)
+				$this->explorer->currentSubChunk->getBlockStateId($x & 0xf, $y & 0xf, $z & 0xf)
 			))
 		) {
 			return;
@@ -53,7 +53,7 @@ class MaskedFillSession extends FillSession {
 		$this->saveChanges($x, $y, $z);
 
 		/** @phpstan-ignore-next-line */
-		$this->explorer->currentSubChunk->setFullBlock($x & 0xf, $y & 0xf, $z & 0xf, $fullStateId);
+		$this->explorer->currentSubChunk->setBlockStateId($x & 0xf, $y & 0xf, $z & 0xf, $fullStateId);
 		$this->blocksChanged++;
 	}
 }

--- a/src/czechpmdevs/buildertools/event/listener/EventListener.php
+++ b/src/czechpmdevs/buildertools/event/listener/EventListener.php
@@ -126,7 +126,7 @@ class EventListener implements Listener {
 					"§aName: §7" . $block->getName() . "\n" .
 					"§aPosition: §7" . $block->getPosition()->getFloorX() . ";" . $block->getPosition()->getFloorY() . ";" . $block->getPosition()->getFloorZ() . " (" . ($block->getPosition()->getFloorX() >> 4) . ";" . ($block->getPosition()->getFloorZ() >> 4) . ")\n" .
 					"§aWorld: §7" . $world->getDisplayName() . "\n" .
-					"§aBiome: §7" . $world->getBiomeId($block->getPosition()->getFloorX(), $block->getPosition()->getFloorZ()) . " (" . $world->getBiome($block->getPosition()->getFloorX(), $block->getPosition()->getFloorZ())->getName() . ")"
+					"§aBiome: §7" . $world->getBiomeId($block->getPosition()->getFloorX(), $block->getPosition()->getFloorY(), $block->getPosition()->getFloorZ()) . " (" . $world->getBiome($block->getPosition()->getFloorX(), $block->getPosition()->getFloorY(), $block->getPosition()->getFloorZ())->getName() . ")"
 				);
 			}
 		}

--- a/src/czechpmdevs/buildertools/schematics/SchematicsManager.php
+++ b/src/czechpmdevs/buildertools/schematics/SchematicsManager.php
@@ -92,7 +92,7 @@ class SchematicsManager {
 				return;
 			}
 
-			self::$loadedSchematics[$task->name] = igbinary_unserialize($task->blockStorage)->asBlockArray();
+			self::$loadedSchematics[$task->name] = $task->blockStorage->deserialize()->asBlockArray();
 			$callback(SchematicActionResult::success($timer->time()));
 		});
 	}

--- a/src/czechpmdevs/buildertools/schematics/SchematicsManager.php
+++ b/src/czechpmdevs/buildertools/schematics/SchematicsManager.php
@@ -92,7 +92,7 @@ class SchematicsManager {
 				return;
 			}
 
-			self::$loadedSchematics[$task->name] = $task->blockStorage->asBlockArray();
+			self::$loadedSchematics[$task->name] = igbinary_unserialize($task->blockStorage)->asBlockArray();
 			$callback(SchematicActionResult::success($timer->time()));
 		});
 	}

--- a/src/czechpmdevs/buildertools/utils/BlockFacingHelper.php
+++ b/src/czechpmdevs/buildertools/utils/BlockFacingHelper.php
@@ -22,7 +22,7 @@ namespace czechpmdevs\buildertools\utils;
 
 use InvalidArgumentException;
 use pocketmine\block\Block;
-use pocketmine\block\BlockFactory;
+use pocketmine\block\RuntimeBlockStateRegistry;
 use pocketmine\math\Axis;
 use pocketmine\math\Facing;
 use pocketmine\utils\SingletonTrait;
@@ -113,7 +113,7 @@ class BlockFacingHelper {
 			return;
 		}
 
-		foreach(BlockFactory::getInstance()->getAllKnownStates() as $block) {
+		foreach(RuntimeBlockStateRegistry::getInstance()->getAllKnownStates() as $block) {
 			if($this->hasFacingTrait($block)) {
 				$originalFullId = $block->getStateId();
 
@@ -151,7 +151,7 @@ class BlockFacingHelper {
 			return;
 		}
 
-		foreach(BlockFactory::getInstance()->getAllKnownStates() as $block) {
+		foreach(RuntimeBlockStateRegistry::getInstance()->getAllKnownStates() as $block) {
 			if($this->hasFacingTrait($block)) {
 				$sourceId = $block->getStateId();
 				$sourceFacing = $block->getFacing(); // @phpstan-ignore-line

--- a/src/czechpmdevs/buildertools/utils/StringToBlockParser.php
+++ b/src/czechpmdevs/buildertools/utils/StringToBlockParser.php
@@ -6,6 +6,7 @@ namespace czechpmdevs\buildertools\utils;
 
 use InvalidArgumentException;
 use pocketmine\block\Block;
+use pocketmine\block\RuntimeBlockStateRegistry;
 use pocketmine\block\VanillaBlocks;
 use pocketmine\item\StringToItemParser;
 use pocketmine\utils\SingletonTrait;

--- a/src/czechpmdevs/buildertools/utils/StringToBlockParser.php
+++ b/src/czechpmdevs/buildertools/utils/StringToBlockParser.php
@@ -6,7 +6,6 @@ namespace czechpmdevs\buildertools\utils;
 
 use InvalidArgumentException;
 use pocketmine\block\Block;
-use pocketmine\block\BlockFactory;
 use pocketmine\block\VanillaBlocks;
 use pocketmine\item\StringToItemParser;
 use pocketmine\utils\SingletonTrait;
@@ -44,7 +43,7 @@ final class StringToBlockParser extends StringToTParser {
 			$result->register($alias, fn() => $item->getBlock());
 		}
 
-		foreach(BlockFactory::getInstance()->getAllKnownStates() as $state) {
+		foreach(RuntimeBlockStateRegistry::getInstance()->getAllKnownStates() as $state) {
 			try {
 				$result->register("{$state->getStateId()}", fn() => $state);
 			} catch(InvalidArgumentException) {


### PR DESCRIPTION
- Initial support of subchunks on Y axis
- Correctly renamed class (BlockFactory) and method (getFullBlock & setFullBlock)
- Fix a non thread safe object in an async task (since pthreads 5 objects are not serialized by default so we need to do it ourselves)
- Fix the imports of the plugin logger in async tasks (it seems not used, is it still usefull to keep it ?) to a global logger

Main functionnalities seems to works but I'm having issue when pasting schematics on the block conversion, each block becomes a info update block whatever which format I use.